### PR TITLE
Switching to QR-based projection.

### DIFF
--- a/ORTHOP
+++ b/ORTHOP
@@ -1,8 +1,9 @@
       parameter (ktot = lx1*ly1*lz1*lelt)
       parameter (laxt = mxprev)
 c
-      common /prthoi/ napprox(2)
+      common /prthoi/ napprox(3)
       common /orthov/ approx(ktot,0:laxt)
+      common /orthoh/ h_approx(laxt, laxt)
       common /prthoc/ name4
       character*4     name4
 

--- a/ORTHOP
+++ b/ORTHOP
@@ -3,7 +3,7 @@
 c
       common /prthoi/ napprox(4)
       common /orthov/ approx(ktot,0:laxt)
-      common /orthoh/ h_approx(laxt, laxt)
+      common /orthoh/ h_approx(laxt*laxt)
       common /prthoc/ name4
       character*4     name4
 

--- a/ORTHOP
+++ b/ORTHOP
@@ -1,7 +1,7 @@
       parameter (ktot = lx1*ly1*lz1*lelt)
       parameter (laxt = mxprev)
 c
-      common /prthoi/ napprox(3)
+      common /prthoi/ napprox(4)
       common /orthov/ approx(ktot,0:laxt)
       common /orthoh/ h_approx(laxt, laxt)
       common /prthoc/ name4

--- a/ORTHOT
+++ b/ORTHOT
@@ -4,7 +4,8 @@ c
 c     parameter (ktot = 1)
 c     parameter (laxt = 1)
 c
-      common /trthoi/ napprox(2)
+      common /trthoi/ napprox(3)
       common /trthov/ approx(ktot,0:laxt)
+      common /trthoh/ h_approx(laxt, laxt)
       common /trthoc/ name4
       character*4     name4

--- a/ORTHOT
+++ b/ORTHOT
@@ -6,6 +6,6 @@ c     parameter (laxt = 1)
 c
       common /trthoi/ napprox(4)
       common /trthov/ approx(ktot,0:laxt)
-      common /trthoh/ h_approx(laxt, laxt)
+      common /trthoh/ h_approx(laxt*laxt)
       common /trthoc/ name4
       character*4     name4

--- a/ORTHOT
+++ b/ORTHOT
@@ -4,7 +4,7 @@ c
 c     parameter (ktot = 1)
 c     parameter (laxt = 1)
 c
-      common /trthoi/ napprox(3)
+      common /trthoi/ napprox(4)
       common /trthov/ approx(ktot,0:laxt)
       common /trthoh/ h_approx(laxt, laxt)
       common /trthoc/ name4

--- a/VPROJ
+++ b/VPROJ
@@ -1,4 +1,5 @@
       parameter (ktop = lelv*lx1*ly1*lz1)
-      common /wrthoi/ ivproj(2,6)
-      common /wrthov/  vproj(ktop*mxprev,2*ldim)
+      common /wrthoi/ ivproj(3,6)
+      common /wrthov/ vproj(ktop*mxprev,2*ldim)
+      common /wrthoh/ h_approx(mxprev, mxprev, 2*ldim)
 

--- a/VPROJ
+++ b/VPROJ
@@ -1,5 +1,5 @@
       parameter (ktop = lelv*lx1*ly1*lz1)
-      common /wrthoi/ ivproj(3,6)
+      common /wrthoi/ ivproj(4,6)
       common /wrthov/ vproj(ktop*mxprev,2*ldim)
       common /wrthoh/ h_approx(mxprev, mxprev, 2*ldim)
 

--- a/VPROJ
+++ b/VPROJ
@@ -1,5 +1,5 @@
       parameter (ktop = lelv*lx1*ly1*lz1)
       common /wrthoi/ ivproj(4,6)
-      common /wrthov/ vproj(ktop*mxprev,2*ldim)
-      common /wrthoh/ h_approx(mxprev, mxprev, 2*ldim)
+      common /wrthov/ vproj(ktop*(mxprev+1),2*ldim)
+      common /wrthoh/ h_approx(mxprev*mxprev, 2*ldim)
 

--- a/conduct.f
+++ b/conduct.f
@@ -86,13 +86,13 @@ c    $                 ,IMESH,TOLHT(IFIELD),NMXH,isd)
      $                   ,tmask(1,1,1,1,ifield-1)
      $                   ,tmult(1,1,1,1,ifield-1)
      $                   ,imesh,tolht(ifield),nmxh,1
-     $                   ,approx,napprox,bintm1)
+     $                   ,approx,h_approx,napprox,bintm1)
          else
            call hsolve  (name4,TA,TB,H1,H2 
      $                   ,tmask(1,1,1,1,ifield-1)
      $                   ,tmult(1,1,1,1,ifield-1)
      $                   ,imesh,tolht(ifield),nmxh,1
-     $                   ,approx,napprox,binvm1)
+     $                   ,approx,h_approx,napprox,binvm1)
          endif 
 
          call add2    (t(1,1,1,1,ifield-1),ta,n)

--- a/induct.f
+++ b/induct.f
@@ -1048,7 +1048,7 @@ C
  
       mtmp        = param(93)
       do i=1,2*ndim
-         ivproj(1,i) = min(mxprev,mtmp) - 1
+         ivproj(1,i) = min(mxprev,mtmp) 
       enddo
  
       imesh = 1
@@ -1062,25 +1062,25 @@ C
          if (ifield.eq.1) then
             call hsolve ('velx',o1,i1,h1,h2,v1mask,vmult
      $                   ,imesh,tolh,nmxhi,1
-     $                   ,vproj(1,1),h_approx(1,1,1),ivproj(1,1),binvm1)
+     $                   ,vproj(1,1),h_approx(1,1),ivproj(1,1),binvm1)
             call hsolve ('vely',o2,i2,h1,h2,v2mask,vmult
      $                   ,imesh,tolh,nmxhi,2
-     $                   ,vproj(1,2),h_approx(1,1,2),ivproj(1,2),binvm1)
+     $                   ,vproj(1,2),h_approx(1,2),ivproj(1,2),binvm1)
             if (if3d)
      $      call hsolve ('velz',o3,i3,h1,h2,v3mask,vmult
      $                   ,imesh,tolh,nmxhi,3
-     $                   ,vproj(1,3),h_approx(1,1,3),ivproj(1,3),binvm1)
+     $                   ,vproj(1,3),h_approx(1,3),ivproj(1,3),binvm1)
          else  ! B-field
             call hsolve (' Bx ',o1,i1,h1,h2,b1mask,vmult
      $                   ,imesh,tolh,nmxhi,1
-     $                   ,vproj(1,4),h_approx(1,1,4),ivproj(1,4),binvm1)
+     $                   ,vproj(1,4),h_approx(1,4),ivproj(1,4),binvm1)
             call hsolve (' By ',o2,i2,h1,h2,b2mask,vmult
      $                   ,imesh,tolh,nmxhi,2
-     $                   ,vproj(1,5),h_approx(1,1,5),ivproj(1,5),binvm1)
+     $                   ,vproj(1,5),h_approx(1,5),ivproj(1,5),binvm1)
             if (if3d)
      $      call hsolve (' Bz ',o3,i3,h1,h2,b3mask,vmult
      $                   ,imesh,tolh,nmxhi,3
-     $                   ,vproj(1,6),h_approx(1,1,6),ivproj(1,6),binvm1)
+     $                   ,vproj(1,6),h_approx(1,6),ivproj(1,6),binvm1)
          endif
       endif
 C

--- a/induct.f
+++ b/induct.f
@@ -1061,26 +1061,26 @@ C
       else
          if (ifield.eq.1) then
             call hsolve ('velx',o1,i1,h1,h2,v1mask,vmult
-     $                         ,imesh,tolh,nmxhi,1
-     $                         ,vproj(1,1),ivproj(1,1),binvm1)
+     $                   ,imesh,tolh,nmxhi,1
+     $                   ,vproj(1,1),h_approx(1,1,1),ivproj(1,1),binvm1)
             call hsolve ('vely',o2,i2,h1,h2,v2mask,vmult
-     $                         ,imesh,tolh,nmxhi,2
-     $                         ,vproj(1,2),ivproj(1,2),binvm1)
+     $                   ,imesh,tolh,nmxhi,2
+     $                   ,vproj(1,2),h_approx(1,1,2),ivproj(1,2),binvm1)
             if (if3d)
      $      call hsolve ('velz',o3,i3,h1,h2,v3mask,vmult
-     $                         ,imesh,tolh,nmxhi,3
-     $                         ,vproj(1,3),ivproj(1,3),binvm1)
+     $                   ,imesh,tolh,nmxhi,3
+     $                   ,vproj(1,3),h_approx(1,1,3),ivproj(1,3),binvm1)
          else  ! B-field
             call hsolve (' Bx ',o1,i1,h1,h2,b1mask,vmult
-     $                         ,imesh,tolh,nmxhi,1
-     $                         ,vproj(1,4),ivproj(1,4),binvm1)
+     $                   ,imesh,tolh,nmxhi,1
+     $                   ,vproj(1,4),h_approx(1,1,4),ivproj(1,4),binvm1)
             call hsolve (' By ',o2,i2,h1,h2,b2mask,vmult
-     $                         ,imesh,tolh,nmxhi,2
-     $                         ,vproj(1,5),ivproj(1,5),binvm1)
+     $                   ,imesh,tolh,nmxhi,2
+     $                   ,vproj(1,5),h_approx(1,1,5),ivproj(1,5),binvm1)
             if (if3d)
      $      call hsolve (' Bz ',o3,i3,h1,h2,b3mask,vmult
-     $                         ,imesh,tolh,nmxhi,3
-     $                         ,vproj(1,6),ivproj(1,6),binvm1)
+     $                   ,imesh,tolh,nmxhi,3
+     $                   ,vproj(1,6),h_approx(1,1,6),ivproj(1,6),binvm1)
          endif
       endif
 C

--- a/navier4.f
+++ b/navier4.f
@@ -529,7 +529,7 @@ c
         enddo
       enddo
       call dsyev('V', 'U', napprox(2), 
-     $           tmp_mat, napprox(1),
+     $           tmp_mat, mxprev,
      $           tmp_vec,
      $           wl, ntot, ierr)
       call col3    (wl, r, vml, ntot)

--- a/navier4.f
+++ b/navier4.f
@@ -686,24 +686,24 @@ c
       real    dtold
       save    dtold
       data    dtold/0.0/
+
+      real hash
+      integer hash_int
+      equivalence (hash, hash_int)
+
 c
 c     First, we have to decide if the dt has changed.
 c
       ifupdate = .false.
-      if (dt.ne.dtold) then
-         dtold    = dt
-         name_old = name4
-         ifnewdt  = .true.
-         ifupdate = .true.
-      elseif (ifnewdt) then
-         if (name4.eq.name_old) then
-            ifnewdt = .false.
-         else
-            ifupdate = .true.
-         endif
+      hash = 0.
+      do i = 1, lt
+        hash = hash + h1(i)**(mod(i, 3) + 1)
+        hash = hash + h2(i)**(mod(i, 3) + 1)
+      enddo
+      if (hash_int /= napprox(4)) then
+        ifupdate = .true.
       endif
-      if (ifvarp(ifield)) ifupdate = .true.
-      if (iflomach)       ifupdate = .true.
+      napprox(4) = hash_int
 
       if (ifupdate) then    ! reorthogonalize 
          n_sav = napprox(2)

--- a/navier4.f
+++ b/navier4.f
@@ -468,7 +468,8 @@ C
 c-----------------------------------------------------------------------
 c     THE ROUTINES BELOW ARE THE NEW Helmholtz projectors
 c-----------------------------------------------------------------------
-      subroutine projh(r,h1,h2,bi,vml,vmk,approx,napprox,wl,ws,name4)
+      subroutine projh(r,h1,h2,bi,vml,vmk,
+     $                 approx,h_approx,napprox,wl,ws,name4)
 C
 C     Orthogonalize the rhs wrt previous rhs's for which we already
 C     know the soln.
@@ -487,6 +488,7 @@ c
       include 'MASS'
       include 'SOLN'
       include 'TSTEP'
+      common /newnewproj/ tmp_mat(mxprev,mxprev), tmp_vec(mxprev)
 c
       parameter(lt=lx1*ly1*lz1*lelt)
 C
@@ -494,8 +496,11 @@ C
       real bi(1)
       real wl(1),ws(1)
       real approx(lt,0:1)
-      integer napprox(2)
+      integer napprox(3)
+      real h_approx(napprox(1), napprox(1))
       character*4 name4
+      real zero, one
+      parameter (zero = 0., one = 1.)
 c
       n_max = napprox(1)
       n_sav = napprox(2)
@@ -512,20 +517,42 @@ c
       if (alpha1.gt.0) alpha1 = sqrt(alpha1/vol)
 c
 c     Update approximation space if dt has changed
-      call updrhsh(approx,napprox,h1,h2,vml,vmk,ws,name4)
+      call updrhsh(approx,h_approx,napprox,h1,h2,vml,vmk,ws,name4)
 c
 c
 c     Perform Gram-Schmidt for previous soln's
 c
-      do i=1,n_sav
-         ws(i) = vlsc3(r,approx(1,i),vml,ntot)
+
+      do i = 1, napprox(2)
+        do j = 1, napprox(2)
+          tmp_mat(i,j) = h_approx(i,j)
+        enddo
       enddo
-      call gop    (ws,ws(n_sav+1),'+  ',n_sav)
-c
-      call cmult2   (approx(1,0),approx(1,1),ws(1),ntot)
-      do i=2,n_sav
-         call add2s2(approx(1,0),approx(1,i),ws(i),ntot)
+      call dsyev('V', 'U', napprox(2), 
+     $           tmp_mat, napprox(1),
+     $           tmp_vec,
+     $           wl, ntot, ierr)
+      call col3    (wl, r, vml, ntot)
+      call dgemv('T', ntot, napprox(2), 
+     $           one,  approx(1,1), ntot,
+     $                 wl, 1,
+     $           zero, ws, 1)
+      call gop(ws, ws(1+napprox(2)), '+  ', napprox(2))
+      do i = 1, napprox(2)
+        call col3(wl, tmp_mat(1,i), ws, napprox(2))
+        tmp_vec(i) = vlsum(wl, napprox(2)) / tmp_vec(i)
       enddo
+      do i = 1, napprox(2)
+        ws(i) = 0.
+        do j = 1, napprox(2)
+          ws(i) = ws(i) + tmp_mat(i,j) * tmp_vec(j)
+        enddo
+      enddo
+      call dgemv('N', ntot, napprox(2), 
+     $           one,  approx(1,1), ntot,
+     $                 ws, 1, 
+     $           zero, approx(1,0), 1)
+
 c
       call axhelm  (wl,approx(1,0),h1,h2,1,1)
       call col2    (wl,vmk,ntot)
@@ -547,7 +574,8 @@ c
       return
       end
 c-----------------------------------------------------------------------
-      subroutine gensh(v1,h1,h2,vml,vmk,approx,napprox,wl,ws,name4)
+      subroutine gensh(v1,h1,h2,vml,vmk, 
+     $                 approx,h_approx,napprox,wl,ws,name4)
 c
 c     Reconstruct the solution to the original problem by adding back
 c     the previous solutions
@@ -564,7 +592,8 @@ c
       real v1(1),h1(1),h2(1),vml(1),vmk(1)
       real wl(1),ws(1)
       real approx(lt,0:1)
-      integer napprox(2)
+      integer napprox(3)
+      real h_approx(1)
       character*4 name4
 c
       n_max = napprox(1)
@@ -573,38 +602,20 @@ c
 c
 c     Reconstruct solution and save current du
 c
-      if (n_sav.lt.n_max) then
-c
-         if (niterhm.gt.0) then      ! new vector not in space
-            n_sav = n_sav+1
-            call copy(approx(1,n_sav),v1,ntot)
-            call add2(v1,approx(1,0),ntot)
-c           orthogonalize rhs against previous rhs and normalize
-            call hconj(approx,n_sav,h1,h2,vml,vmk,ws,name4,ierr)
+      call add2(v1,approx(1,0),ntot)
+      if (niterhm .lt. 1) return
+      napprox(2) = min(napprox(2) + 1, napprox(1))
+      napprox(3) = mod(napprox(3), napprox(1)) + 1
+      call copy(approx(1,napprox(3)), v1, ntot)
 
-c           if (ierr.ne.0) n_sav = n_sav-1
-            if (ierr.ne.0) n_sav = 0
-
-         else
-
-            call add2(v1,approx(1,0),ntot)
-
-         endif
-      else
-         n_sav = 1
-         call add2(v1,approx(1,0),ntot)
-         call copy(approx(1,n_sav),v1,ntot)
-c        normalize
-         call hconj(approx,n_sav,h1,h2,vml,vmk,ws,name4,ierr)
-         if (ierr.ne.0) n_sav = 0
-      endif
-
-      napprox(2)=n_sav
+      call hconj(approx,h_approx,napprox,napprox(3),
+     $           h1,h2,vml,vmk,ws,name4,ierr)
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine hconj(approx,k,h1,h2,vml,vmk,ws,name4,ierr)
+      subroutine hconj(approx,h_approx, napprox,
+     $                 k,h1,h2,vml,vmk,ws,name4,ierr)
 c
 c     Orthonormalize the kth vector against vector set
 c
@@ -616,75 +627,38 @@ c
       include 'TSTEP'
 c
       parameter  (lt=lx1*ly1*lz1*lelt)
+      integer napprox(3)
       real approx(lt,0:1),h1(1),h2(1),vml(1),vmk(1),ws(1)
+      real h_approx(napprox(1), napprox(1))
+      real one, zero
+      parameter (one = 1., zero = 0.)
       character*4 name4
 c
       ierr=0
       ntot=nx1*ny1*nz1*nelfld(ifield)
 c
+c     Compute H| approx(:,k) >
       call axhelm  (approx(1,0),approx(1,k),h1,h2,1,1)
       call col2    (approx(1,0),vmk,ntot)
-c
-c     Compute part of the norm   (Note:  a(0) already scaled by vml)
-c
-      alpha = glsc2(approx(1,0),approx(1,k),ntot)
-      alph1 = alpha
-c
-c     Gram-Schmidt
-c
-      km1=k-1
-      do i=1,km1
-         ws(i) = vlsc2(approx(1,0),approx(1,i),ntot)
+c MH: do we need this dsavg?
+      call dssum   (approx(1,0),nx1,ny1,nz1)
+      call col2    (approx(1,0),vml ,ntot)
+c     Compute <approx(:,i) | H | approx(:,k)>
+      call dgemv('T', lt, napprox(2), 
+     $           one,  approx(1,1), lt,
+     $                 approx(1,0),  1,
+     $           zero, h_approx(1,k), 1)
+       call gop(h_approx(1,k), ws, '+  ', napprox(1))
+
+c     Symmetry
+      do i = 1, napprox(1)
+        h_approx(k,i) = h_approx(i,k)
       enddo
-      if (km1.gt.0) call gop(ws,ws(k),'+  ',km1)
-c
-      do i=1,km1
-         alpham = -ws(i)
-         call add2s2(approx(1,k),approx(1,i),alpham,ntot)
-         alpha = alpha - ws(i)**2
-      enddo
-c
-c    .Normalize new element in approximation space
-c
-      eps = 1.e-7
-      if (wdsize.eq.8) eps = 1.e-15
-      ratio = alpha/alph1
-c
-      if (ratio.le.0) then
-         ierr=1
-         if (nio.eq.0) write(6,12) istep,name4,k,alpha,alph1
-   12    format(I6,1x,a4,' alpha b4 sqrt:',i4,1p2e12.4)
-      elseif (ratio.le.eps) then
-         ierr=2
-         if (nio.eq.0) write(6,12) istep,name4,k,alpha,alph1
-      else
-         ierr=0
-         alpha = 1.0/sqrt(alpha)
-         call cmult(approx(1,k),alpha,ntot)
-      endif
-c
-      if (ierr.ne.0) then
-         call axhelm  (approx(1,0),approx(1,k),h1,h2,1,1)
-         call col2    (approx(1,0),vmk,ntot)
-c
-c        Compute part of the norm   (Note:  a(0) already scaled by vml)
-c
-         alpha = glsc2(approx(1,0),approx(1,k),ntot)
-         if (nio.eq.0) write(6,12) istep,name4,k,alpha,alph1
-         if (alpha.le.0) then
-            ierr=3
-            if (nio.eq.0) write(6,12) istep,name4,k,alpha,alph1
-            return
-         endif
-         alpha = 1.0/sqrt(alpha)
-         call cmult(approx(1,k),alpha,ntot)
-         ierr = 0
-      endif
-c
+
       return
       end
 c-----------------------------------------------------------------------
-      subroutine updrhsh(approx,napprox,h1,h2,vml,vmk,ws,name4)
+      subroutine updrhsh(approx,h_approx,napprox,h1,h2,vml,vmk,ws,name4)
 c
 c     Reorthogonalize approx if dt has changed
 c
@@ -695,8 +669,9 @@ c
 c
 c
       parameter  (lt=lx1*ly1*lz1*lelt)
+      integer napprox(3)
       real approx(lt,0:1),h1(1),h2(1),vml(1),vmk(1),ws(1)
-      integer napprox(2)
+      real h_approx(1)
       character*4 name4
 c
       logical ifupdate
@@ -735,14 +710,10 @@ c
          l     = 1
          do k=1,n_sav
 c           Orthogonalize kth vector against {v_1,...,v_k-1}
-            if (k.ne.l) then
-               ntot = nx1*ny1*nz1*nelfld(ifield)
-               call copy(approx(1,l),approx(1,k),ntot)
-            endif
-            call hconj(approx,l,h1,h2,vml,vmk,ws,name4,ierr)
-            if (ierr.eq.0) l=l+1
+            napprox(2) = k
+            call hconj(approx,h_approx, napprox, k,
+     $                 h1,h2,vml,vmk,ws,name4,ierr)
          enddo
-         napprox(2)=min(l,n_sav)
       endif
 c
       return
@@ -798,7 +769,7 @@ c
       end
 c-----------------------------------------------------------------------
       subroutine hsolve(name,u,r,h1,h2,vmk,vml,imsh,tol,maxit,isd
-     $                 ,approx,napprox,bi)
+     $                 ,approx,h_approx,napprox,bi)
 c
 c     Either std. Helmholtz solve, or a projection + Helmholtz solve
 c
@@ -815,6 +786,7 @@ c
       REAL           vml  (LX1,LY1,LZ1,1)
       REAL           bi   (LX1,LY1,LZ1,1)
       REAL           approx (1)
+      REAL           h_approx(1)
       integer        napprox(1)
       common /ctmp2/ w1   (lx1,ly1,lz1,lelt)
       common /ctmp3/ w2   (2+2*mxprev)
@@ -845,19 +817,12 @@ c
 
          call col2   (r,vmk,n)
          call dssum  (r,nx1,ny1,nz1)
-
-         call blank (name6,6)
-         call chcopy(name6,name,4)
-         ifwt  = .true.
-         ifvec = .false.
-
-         call project1
-     $       (r,n,approx,napprox,h1,h2,vmk,vml,ifwt,ifvec,name6)
-
+         
+         call projh(r, h1, h2, bi, vml, vmk,
+     $              approx, h_approx, napprox, w1, w2, name)
          call hmhzpf (name,u,r,h1,h2,vmk,vml,imsh,tol,maxit,isd,bi)
-
-         call project2
-     $       (u,n,approx,napprox,h1,h2,vmk,vml,ifwt,ifvec,name6)
+         call gensh(u, h1, h2, vml, vmk, 
+     $              approx, h_approx, napprox, w1, w2, name)
 
       endif
 

--- a/plan4.f
+++ b/plan4.f
@@ -68,7 +68,7 @@ C     first, compute pressure
       call hsolve   ('PRES',dpr,respr,h1,h2 
      $                     ,pmask,vmult
      $                     ,imesh,tolspl,nmxh,1
-     $                     ,approx,napprox,binvm1)
+     $                     ,approx,h_approx,napprox,binvm1)
       call add2    (pr,dpr,ntot1)
       call ortho   (pr)
       tpres=tpres+(dnekclock()-etime1)


### PR DESCRIPTION
QR is more stable than Gram-Schmidt, and allows for the space to
be continuous rolled over rather that dumped entirely.

For the iturb test case, the late-time iteration count is down by
nearly 2x:
```
maxhutch@edoras:~/src/clean-tests/iturb$ grep "PRES gmres:" test.out  | tail
       55 PRES gmres:    6  9.2811E-12  1.3300E-11  1.7386E-08  4.2701E-01  6.7275E-01    F
       56 PRES gmres:    6  1.1794E-11  1.3151E-11  1.8699E-08  4.2644E-01  6.7343E-01    F
       57 PRES gmres:    6  1.2957E-11  1.3007E-11  1.8182E-08  4.2683E-01  6.7248E-01    F
       58 PRES gmres:    6  1.2339E-11  1.2865E-11  1.6503E-08  4.2699E-01  6.7337E-01    F
       59 PRES gmres:    6  1.1540E-11  1.2727E-11  1.4756E-08  4.2673E-01  6.7328E-01    F
       60 PRES gmres:    6  1.0136E-11  1.2592E-11  1.2315E-08  4.2598E-01  6.7441E-01    F
       61 PRES gmres:    6  8.0221E-12  1.2459E-11  1.0399E-08  4.2645E-01  6.7333E-01    F
       62 PRES gmres:    6  7.1430E-12  1.2329E-11  1.0644E-08  4.2811E-01  6.7412E-01    F
       63 PRES gmres:    6  8.2011E-12  1.2202E-11  1.2279E-08  4.2702E-01  6.7261E-01    F
       64 PRES gmres:    6  7.7983E-12  1.2077E-11  1.0548E-08  4.2688E-01  6.7313E-01    F
maxhutch@edoras:~/src/clean-tests/iturb$ grep "PRES gmres:" iturb_ref.out  | tail
       55 PRES gmres:   15  1.1277E-11  1.3300E-11  5.4024E-04  1.0706E+00  1.8302E+00    F
       56 PRES gmres:   15  1.0883E-11  1.3151E-11  5.2089E-04  1.0795E+00  1.8459E+00    F
       57 PRES gmres:   15  1.0504E-11  1.3007E-11  5.0232E-04  1.0741E+00  1.8348E+00    F
       58 PRES gmres:   15  1.0140E-11  1.2865E-11  4.8449E-04  1.0727E+00  1.8368E+00    F
       59 PRES gmres:   15  9.7909E-12  1.2727E-11  4.6738E-04  1.3432E+00  2.2350E+00    F
       60 PRES gmres:   15  9.4555E-12  1.2592E-11  4.5094E-04  1.1154E+00  1.9048E+00    F
       61 PRES gmres:   15  9.1333E-12  1.2459E-11  4.3517E-04  1.1110E+00  1.9014E+00    F
       62 PRES gmres:   15  8.8238E-12  1.2329E-11  4.2002E-04  1.0921E+00  1.8722E+00    F
       63 PRES gmres:   15  8.5263E-12  1.2202E-11  4.0547E-04  1.0986E+00  1.8778E+00    F
       64 PRES gmres:   15  8.2404E-12  1.2077E-11  3.9150E-04  1.1307E+00  1.9244E+00    F
```